### PR TITLE
Separate Page and PageDomainModel

### DIFF
--- a/zScanner.xcodeproj/project.pbxproj
+++ b/zScanner.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		BD8F753E23241F660086B097 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8F753D23241F660086B097 /* SplashViewController.swift */; };
 		BD94413D231F19F10085BB4D /* StatusNetworkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD94413C231F19F10085BB4D /* StatusNetworkModel.swift */; };
 		BD94413F231F1A540085BB4D /* GetStatusRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD94413E231F1A540085BB4D /* GetStatusRequest.swift */; };
+		BD99E58423F9A5E800792532 /* Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD99E58323F9A5E800792532 /* Page.swift */; };
 		BDA25B1C22EF979A006DA7E4 /* Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA25B1B22EF979A006DA7E4 /* Tracker.swift */; };
 		BDA25B1E22EF99E6006DA7E4 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BDA25B1D22EF99E6006DA7E4 /* GoogleService-Info.plist */; };
 		BDA25B2022EF9C33006DA7E4 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA25B1F22EF9C33006DA7E4 /* Event.swift */; };
@@ -230,6 +231,7 @@
 		BD8F753D23241F660086B097 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		BD94413C231F19F10085BB4D /* StatusNetworkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusNetworkModel.swift; sourceTree = "<group>"; };
 		BD94413E231F1A540085BB4D /* GetStatusRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetStatusRequest.swift; sourceTree = "<group>"; };
+		BD99E58323F9A5E800792532 /* Page.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Page.swift; sourceTree = "<group>"; };
 		BDA25B1B22EF979A006DA7E4 /* Tracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracker.swift; sourceTree = "<group>"; };
 		BDA25B1D22EF99E6006DA7E4 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		BDA25B1F22EF9C33006DA7E4 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
@@ -315,6 +317,7 @@
 				BD2B9E8022EDC1FA00FFCD3B /* DocumentTypeDomainModel.swift */,
 				BD000CD022E497B9001EE38A /* LoginDomainModel.swift */,
 				BDC4A3E222E5008800D1CF6A /* DocumentDomainModel.swift */,
+				BD99E58323F9A5E800792532 /* Page.swift */,
 				BD7EAC3B232583C3002C225A /* PageDomainModel.swift */,
 				BD389A2922F7093B002F935F /* FolderDomainModel.swift */,
 			);
@@ -914,6 +917,7 @@
 				BD59A0AD22E395AF00FA9CD0 /* UIColor.swift in Sources */,
 				BD59A09022E36EF900FA9CD0 /* RequestBehavior.swift in Sources */,
 				BD2F209222EBA7D300534916 /* RealmDatabase.swift in Sources */,
+				BD99E58423F9A5E800792532 /* Page.swift in Sources */,
 				BD88F15B230953C700569D71 /* PageNetworkModel.swift in Sources */,
 				BDDA1271231408C10029A7DF /* SubmitPasswordRequest.swift in Sources */,
 				BD8F753E23241F660086B097 /* SplashViewController.swift in Sources */,

--- a/zScanner/Coordinators/NewDocumentCoordinator.swift
+++ b/zScanner/Coordinators/NewDocumentCoordinator.swift
@@ -138,12 +138,13 @@ class NewDocumentCoordinator: Coordinator {
         pop()
     }
     
-    private func savePagesToDocument(_ pages: [PageDomainModel]) {
+    private func savePagesToDocument(_ pages: [Page]) {
 
         // Store images
         pages
             .enumerated()
             .forEach({ (index, page) in
+                let page = PageDomainModel(page: page, index: index, correlationId: newDocument.id)
                 newDocument.pages.append(page)
             })
         }
@@ -231,7 +232,7 @@ extension NewDocumentCoordinator: ListItemSelectionCoordinator {}
 
 // MARK: - ListItemSelectionCoordinator implementation
 extension NewDocumentCoordinator: NewDocumentPhotosCoordinator {
-    func savePhotos(_ photos: [PageDomainModel]) {
-        savePagesToDocument(photos)
+    func savePages(_ pages: [Page]) {
+        savePagesToDocument(pages)
     }
 }

--- a/zScanner/DomainModel/Page.swift
+++ b/zScanner/DomainModel/Page.swift
@@ -1,0 +1,14 @@
+//
+//  Page.swift
+//  zScanner
+//
+//  Created by Jakub Skořepa on 16/02/2020.
+//  Copyright © 2020 Institut klinické a experimentální medicíny. All rights reserved.
+//
+
+import UIKit
+
+struct Page: Equatable {
+    var image: UIImage
+    var description: String = ""
+}

--- a/zScanner/DomainModel/PageDomainModel.swift
+++ b/zScanner/DomainModel/PageDomainModel.swift
@@ -41,8 +41,8 @@ struct PageDomainModel: Equatable {
 }
 
 extension PageDomainModel {
-    init(image: UIImage, index: Int, correlationId: String, description: String = "") {
-        self.init(id: UUID().uuidString, index: index, correlationId: correlationId, relativePath: "", description: description)
+    init(page: Page, index: Int, correlationId: String) {
+        self.init(id: UUID().uuidString, index: index, correlationId: correlationId, relativePath: "", description: page.description)
         
         self.image = image
     }

--- a/zScanner/ViewControllers/NewDocument/NewDocumentPhotosViewController.swift
+++ b/zScanner/ViewControllers/NewDocument/NewDocumentPhotosViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import RxSwift
 
 protocol NewDocumentPhotosCoordinator: BaseCoordinator {
-    func savePhotos(_ photos: [PageDomainModel])
+    func savePages(_ pages: [Page])
     func showNextStep()
 }
 
@@ -100,29 +100,29 @@ class NewDocumentPhotosViewController: BaseViewController {
     }
     
     private func setupBindings() {
-        viewModel.pictures
+        viewModel.pages
             .bind(
                 to: collectionView.rx.items(cellIdentifier: "PhotoSelectorCollectionViewCell", cellType: PhotoSelectorCollectionViewCell.self),
-                curriedArgument: { [unowned self] (row, image, cell) in
-                    cell.setup(with: image, delegate: self)
+                curriedArgument: { [unowned self] (row, page, cell) in
+                    cell.setup(with: page, delegate: self)
                 }
             )
             .disposed(by: disposeBag)
         
-        viewModel.pictures
+        viewModel.pages
             .subscribe(onNext: { [weak self] pictures in
                 self?.collectionView.backgroundView?.isHidden = pictures.count > 0
             })
             .disposed(by: disposeBag)
         
-        viewModel.pictures
+        viewModel.pages
             .map({ !$0.isEmpty })
             .bind(to: continueButton.rx.isEnabled)
             .disposed(by: disposeBag)
         
         continueButton.rx.tap
             .subscribe(onNext: { [unowned self] in
-                self.coordinator.savePhotos(self.viewModel.pictures.value)
+                self.coordinator.savePages(self.viewModel.pages.value)
                 self.coordinator.showNextStep()
             })
             .disposed(by: disposeBag)
@@ -216,9 +216,8 @@ class NewDocumentPhotosViewController: BaseViewController {
 extension NewDocumentPhotosViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         if let pickedImage = info[.originalImage] as? UIImage {
-            #warning("TODO Am I do it right here?")
-            let pickedPicture = PageDomainModel(image: pickedImage, index: 0, correlationId: "")
-            viewModel.addImage(pickedPicture, fromGallery: picker.sourceType == .photoLibrary)
+            let page = Page(image: pickedImage)
+            viewModel.addPage(page, fromGallery: picker.sourceType == .photoLibrary)
         }
         self.dismiss(animated: true, completion: nil)
     }
@@ -230,7 +229,7 @@ extension NewDocumentPhotosViewController: UIImagePickerControllerDelegate, UINa
 
 // MARK: - PhotoSelectorCellDelegate implementation
 extension NewDocumentPhotosViewController: PhotoSelectorCellDelegate {
-    func delete(image: PageDomainModel) {
-        viewModel.removeImage(image)
+    func delete(page: Page) {
+        viewModel.removePage(page)
     }
 }

--- a/zScanner/ViewModels/NewDocument/NewDocumentPhotosViewModel.swift
+++ b/zScanner/ViewModels/NewDocument/NewDocumentPhotosViewModel.swift
@@ -20,25 +20,25 @@ class NewDocumentPhotosViewModel {
     }
     
     // MARK: Interface
-    let pictures = BehaviorRelay<[PageDomainModel]>(value: [])
+    let pages = BehaviorRelay<[Page]>(value: [])
     
-    func addImage(_ image: PageDomainModel, fromGallery: Bool) {
+    func addPage(_ page: Page, fromGallery: Bool) {
         // Tracking
         tracker.track(.galleryUsed(fromGallery))
         
         // Add image
-        var newArray = pictures.value
-        newArray.append(image)
-        pictures.accept(newArray)
+        var newArray = pages.value
+        newArray.append(page)
+        pages.accept(newArray)
     }
     
-    func removeImage(_ image: PageDomainModel) {
+    func removePage(_ page: Page) {
         // Tracking
         tracker.track(.deleteImage)
 
         // Remove image
-        var newArray = pictures.value
-        _ = newArray.remove(image)
-        pictures.accept(newArray)
+        var newArray = pages.value
+        _ = newArray.remove(page)
+        pages.accept(newArray)
     }
 }

--- a/zScanner/Views/NewDocument/PhotoSelectorCollectionViewCell.swift
+++ b/zScanner/Views/NewDocument/PhotoSelectorCollectionViewCell.swift
@@ -9,16 +9,17 @@
 import UIKit
 
 protocol PhotoSelectorCellDelegate: class {
-    func delete(image: PageDomainModel)
+    func delete(page: Page)
 }
 
 // MARK: -
 class PhotoSelectorCollectionViewCell: UICollectionViewCell {
     
     // MARK: Instance part
-    private var picture: PageDomainModel? {
+    private var page: Page? {
         didSet {
-            imageView.image = picture?.image
+            imageView.image = page?.image
+            textField.text = page?.description
         }
     }
     
@@ -36,12 +37,12 @@ class PhotoSelectorCollectionViewCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        picture = nil
+        page = nil
     }
     
     // MARK: Interface
-    func setup(with picture: PageDomainModel, delegate: PhotoSelectorCellDelegate) {
-        self.picture = picture
+    func setup(with page: Page, delegate: PhotoSelectorCellDelegate) {
+        self.page = page
         self.delegate = delegate
     }
     
@@ -49,8 +50,8 @@ class PhotoSelectorCollectionViewCell: UICollectionViewCell {
     private weak var delegate: PhotoSelectorCellDelegate?
     
     @objc private func deleteImage() {
-        guard let picture = picture else { return }
-        delegate?.delete(image: picture)
+        guard let page = page else { return }
+        delegate?.delete(page: page)
     }
     
     private func setupView() {


### PR DESCRIPTION
@Finemas I told you to convert UIImage into PageDomainModel, but I didn't know it already existed. I have reverted your changes and converted UIImage to Page. The Page contains the image and description. - I should have told you to do this before. My mistake.

I guess it was supposed to be like this from the beginning, but I've just did my life easier and didn't wrap simple UIImage inside Page struct. 

There is still some work that needs to be done. I've just corrected the current state to the right path :) 

Please go through the comments on this PR and ask any questions you have. 

Merge when you are done. I guess there will be a merge conflict with https://github.com/bindworks/zScanner-Medicalc-iOS/pull/7 Let me know when you merge one of them, I will rebase the second branch to keep nice git history. 